### PR TITLE
Changes `layout: nil` to `layout: null`

### DIFF
--- a/_posts/2014-02-18-excluding-jsonify-your-site.md
+++ b/_posts/2014-02-18-excluding-jsonify-your-site.md
@@ -13,7 +13,7 @@ I created a file called `site.json` and added these contents:
 {% highlight html %}
   {% raw %}
     ---
-    layout: nil
+    layout: null
     ---
 
     [


### PR DESCRIPTION
Using `layout: nil` produces a build warning.